### PR TITLE
Allow users to set component names in remote state

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -2,7 +2,7 @@ module "account_map" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component   = "account-map"
+  component   = var.account_map_component_name
   environment = var.account_map_environment_name
   stage       = var.account_map_stage_name
   tenant      = var.account_map_tenant_name

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -389,3 +389,9 @@ variable "iam_policy_statements" {
   description = "Map of IAM policy statements to use in the bucket policy."
   default     = {}
 }
+
+variable "account_map_component_name" {
+  type        = string
+  description = "The name of the account-map component"
+  default     = "account-map"
+}


### PR DESCRIPTION
Allow users to set component names in remote state.

* Defined input variables `account_map_component_name`.
* Variable defaults to preserving the behaviour of the current version.
* Remote state uses this variable to pull in the state of the components.
* This update allows the codebase to adopt more standardized structure and naming practices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Made the account-map component name configurable through a new variable, allowing users to customize its value if needed. The default remains "account-map".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->