### PR TITLE
feat: add account_map_enabled variable for static account mapping

### DIFF
--- a/src/providers.tf
+++ b/src/providers.tf
@@ -1,3 +1,34 @@
+variable "account_map_enabled" {
+  type        = bool
+  description = <<-EOT
+    Enable the account map component lookup. When disabled, use the `account_map` variable to provide static account mapping.
+    EOT
+  default     = true
+}
+
+variable "account_map" {
+  type = object({
+    full_account_map              = map(string)
+    audit_account_account_name    = optional(string, "")
+    root_account_account_name     = optional(string, "")
+    identity_account_account_name = optional(string, "")
+    aws_partition                 = optional(string, "aws")
+    iam_role_arn_templates        = optional(map(string), {})
+  })
+  description = <<-EOT
+    Static account map to use when `account_map_enabled` is `false`. Map of account names (tenant-stage format) to account IDs.
+    Optional attributes support component-specific functionality (e.g., audit_account_account_name for cloudtrail).
+    EOT
+  default = {
+    full_account_map              = {}
+    audit_account_account_name    = ""
+    root_account_account_name     = ""
+    identity_account_account_name = ""
+    aws_partition                 = "aws"
+    iam_role_arn_templates        = {}
+  }
+}
+
 provider "aws" {
   region = var.region
 

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -3,9 +3,12 @@ module "account_map" {
   version = "1.8.0"
 
   component   = var.account_map_component_name
-  environment = var.account_map_environment_name
-  stage       = var.account_map_stage_name
-  tenant      = var.account_map_tenant_name
+  environment = var.account_map_enabled ? var.account_map_environment_name : ""
+  stage       = var.account_map_enabled ? var.account_map_stage_name : ""
+  tenant      = var.account_map_enabled ? var.account_map_tenant_name : ""
+
+  bypass   = !var.account_map_enabled
+  defaults = var.account_map
 
   context = module.this.context
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -396,37 +396,6 @@ variable "account_map_component_name" {
   default     = "account-map"
 }
 
-variable "account_map_enabled" {
-  type        = bool
-  description = <<-EOT
-    Enable the account map component lookup. When disabled, use the `account_map` variable to provide static account mapping.
-    EOT
-  default     = true
-}
-
-variable "account_map" {
-  type = object({
-    full_account_map              = map(string)
-    audit_account_account_name    = optional(string, "")
-    root_account_account_name     = optional(string, "")
-    identity_account_account_name = optional(string, "")
-    aws_partition                 = optional(string, "aws")
-    iam_role_arn_templates        = optional(map(string), {})
-  })
-  description = <<-EOT
-    Static account map to use when `account_map_enabled` is `false`. Map of account names (tenant-stage format) to account IDs.
-    Optional attributes support component-specific functionality (e.g., audit_account_account_name for cloudtrail).
-    EOT
-  default = {
-    full_account_map              = {}
-    audit_account_account_name    = ""
-    root_account_account_name     = ""
-    identity_account_account_name = ""
-    aws_partition                 = "aws"
-    iam_role_arn_templates        = {}
-  }
-}
-
 variable "event_notification_details" {
   type = object({
     enabled     = bool

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -396,6 +396,37 @@ variable "account_map_component_name" {
   default     = "account-map"
 }
 
+variable "account_map_enabled" {
+  type        = bool
+  description = <<-EOT
+    Enable the account map component lookup. When disabled, use the `account_map` variable to provide static account mapping.
+    EOT
+  default     = true
+}
+
+variable "account_map" {
+  type = object({
+    full_account_map              = map(string)
+    audit_account_account_name    = optional(string, "")
+    root_account_account_name     = optional(string, "")
+    identity_account_account_name = optional(string, "")
+    aws_partition                 = optional(string, "aws")
+    iam_role_arn_templates        = optional(map(string), {})
+  })
+  description = <<-EOT
+    Static account map to use when `account_map_enabled` is `false`. Map of account names (tenant-stage format) to account IDs.
+    Optional attributes support component-specific functionality (e.g., audit_account_account_name for cloudtrail).
+    EOT
+  default = {
+    full_account_map              = {}
+    audit_account_account_name    = ""
+    root_account_account_name     = ""
+    identity_account_account_name = ""
+    aws_partition                 = "aws"
+    iam_role_arn_templates        = {}
+  }
+}
+
 variable "event_notification_details" {
   type = object({
     enabled     = bool


### PR DESCRIPTION
## What
Add conditional remote state lookup for account-map component:
- Add `account_map_enabled` variable (default: true) - toggle remote state vs static mapping
- Add `account_map` variable - static account map object with full_account_map and account names
- When `account_map_enabled` is true, use remote state lookup (existing behavior)
- When `account_map_enabled` is false, bypass remote state and use static `account_map` variable

## Why
This allows the component to function without the account-map dependency, supporting the account-map deprecation effort by enabling static account mappings.

## References
- Part of account-map deprecation effort

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Account mapping functionality can now be conditionally enabled or disabled
  * AWS provider configuration now supports IAM role assumption capabilities
  * New configuration variables added for account mapping settings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->