### PR TITLE
Add source_policy_enabled variable to gate bucket policy creation

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -51,7 +51,7 @@ module "s3_bucket" {
   ignore_public_acls           = var.ignore_public_acls
   restrict_public_buckets      = var.restrict_public_buckets
   logging                      = local.logging
-  source_policy_documents      = [local.bucket_policy]
+  source_policy_documents      = var.source_policy_enabled ? [local.bucket_policy] : []
   privileged_principal_actions = var.privileged_principal_actions
   privileged_principal_arns    = var.privileged_principal_arns
   s3_object_ownership          = var.s3_object_ownership

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -366,6 +366,17 @@ variable "bucket_key_enabled" {
   EOT
 }
 
+variable "source_policy_enabled" {
+  type        = bool
+  default     = true
+  description = <<-EOT
+    Whether to pass source policy documents to the S3 module.
+    Set to `false` to prevent the module from creating an `aws_s3_bucket_policy` resource
+    based on `iam_policy_statements`. This is useful when importing existing buckets that have
+    their own policies which should not be managed by Terraform.
+    EOT
+}
+
 variable "custom_policy_actions" {
   description = "List of S3 Actions for the custom policy"
   type        = list(string)

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -371,8 +371,9 @@ variable "source_policy_enabled" {
   default     = true
   description = <<-EOT
     Whether to pass source policy documents to the S3 module.
-    Set to `false` to prevent the module from creating an `aws_s3_bucket_policy` resource
-    based on `iam_policy_statements`. This is useful when importing existing buckets that have
+    Set to `false` to prevent the module from creating an `aws_s3_bucket_policy` resource.
+    This suppresses both the `iam_policy_statements` policy and the custom policy
+    (controlled by `custom_policy_enabled`). Useful when importing existing buckets that have
     their own policies which should not be managed by Terraform.
     EOT
 }


### PR DESCRIPTION
## What

Adds a `source_policy_enabled` variable (bool, default `true`) that controls whether `source_policy_documents` is passed to the underlying `cloudposse/s3-bucket/aws` module.

When set to `false`, the module receives an empty `source_policy_documents = []`, which prevents it from creating an `aws_s3_bucket_policy` resource.

## Why

When importing existing S3 buckets into Terraform state, buckets may already have bucket policies that should not be managed by Terraform. The current component always passes `source_policy_documents = [local.bucket_policy]`, which forces the module to create an `aws_s3_bucket_policy` resource — even when `iam_policy_statements` is empty. This makes it impossible to import a bucket without also importing or overwriting its policy.

Setting `source_policy_enabled = false` allows the bucket to be imported and managed by Terraform while leaving the existing AWS bucket policy untouched.

Defaults to `true`, so there is no behavior change for existing deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a toggle to control whether S3 source policy documents are applied. When disabled, the policy is omitted and no bucket policy is created; default remains enabled to preserve current behavior and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->