### PR TITLE
Add S3 Intelligent-Tiering archive configuration support

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -36,8 +36,7 @@ module "bucket_policy" {
 }
 
 module "s3_bucket" {
-  source  = "cloudposse/s3-bucket/aws"
-  version = "4.10.0"
+  source = "git::https://github.com/cloudposse/terraform-aws-s3-bucket.git?ref=add-intelligent-tiering-configuration"
 
   bucket_name = var.bucket_name
 
@@ -72,6 +71,9 @@ module "s3_bucket" {
 
   # Object lifecycle rules
   lifecycle_configuration_rules = var.lifecycle_configuration_rules
+
+  # Intelligent-Tiering archive configuration
+  intelligent_tiering_configuration = var.intelligent_tiering_configuration
 
   # Object encryption
   sse_algorithm      = var.sse_algorithm

--- a/src/main.tf
+++ b/src/main.tf
@@ -36,7 +36,8 @@ module "bucket_policy" {
 }
 
 module "s3_bucket" {
-  source = "git::https://github.com/cloudposse/terraform-aws-s3-bucket.git?ref=add-intelligent-tiering-configuration"
+  source  = "cloudposse/s3-bucket/aws"
+  version = "4.10.0"
 
   bucket_name = var.bucket_name
 
@@ -73,7 +74,8 @@ module "s3_bucket" {
   lifecycle_configuration_rules = var.lifecycle_configuration_rules
 
   # Intelligent-Tiering archive configuration
-  intelligent_tiering_configuration = var.intelligent_tiering_configuration
+  # TODO: Uncomment after upgrading module to include intelligent tiering support
+  # intelligent_tiering_configuration = var.intelligent_tiering_configuration
 
   # Object encryption
   sse_algorithm      = var.sse_algorithm

--- a/src/main.tf
+++ b/src/main.tf
@@ -37,7 +37,7 @@ module "bucket_policy" {
 
 module "s3_bucket" {
   source  = "cloudposse/s3-bucket/aws"
-  version = "4.10.0"
+  version = "4.11.0"
 
   bucket_name = var.bucket_name
 
@@ -74,8 +74,7 @@ module "s3_bucket" {
   lifecycle_configuration_rules = var.lifecycle_configuration_rules
 
   # Intelligent-Tiering archive configuration
-  # TODO: Uncomment after upgrading module to include intelligent tiering support
-  # intelligent_tiering_configuration = var.intelligent_tiering_configuration
+  intelligent_tiering_configuration = var.intelligent_tiering_configuration
 
   # Object encryption
   sse_algorithm      = var.sse_algorithm

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -408,6 +408,28 @@ variable "account_map_component_name" {
   default     = "account-map"
 }
 
+variable "intelligent_tiering_configuration" {
+  type = list(object({
+    name   = string
+    status = optional(string, "Enabled")
+    filter = optional(object({
+      prefix = optional(string)
+      tags   = optional(map(string))
+    }))
+    tiering = list(object({
+      access_tier = string
+      days        = number
+    }))
+  }))
+  default     = []
+  description = <<-EOT
+    A list of S3 Intelligent-Tiering configurations for the bucket.
+    Each configuration controls archive access tiers within the INTELLIGENT_TIERING storage class.
+    `access_tier` must be `ARCHIVE_ACCESS` or `DEEP_ARCHIVE_ACCESS`.
+  EOT
+  nullable    = false
+}
+
 variable "event_notification_details" {
   type = object({
     enabled     = bool

--- a/test/component_test.go
+++ b/test/component_test.go
@@ -51,6 +51,17 @@ type BucketPolicy struct {
 	} `json:"Statement"`
 }
 
+type IntelligentTieringConfig struct {
+	Name    string
+	Status  string
+	Tiers   []IntelligentTieringTier
+}
+
+type IntelligentTieringTier struct {
+	AccessTier string
+	Days       int32
+}
+
 type EventNotificationConfig struct {
 	EventBridgeConfiguration     bool
 	LambdaFunctionConfigurations []string
@@ -171,6 +182,67 @@ func getS3BucketEventNotification(t *testing.T, region string, bucketName string
 	}
 
 	return config
+}
+
+func getS3BucketIntelligentTieringConfigs(t *testing.T, region string, bucketName string) []IntelligentTieringConfig {
+	ctx := context.Background()
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	require.NoError(t, err)
+
+	client := s3.NewFromConfig(cfg)
+	result, err := client.ListBucketIntelligentTieringConfigurations(ctx, &s3.ListBucketIntelligentTieringConfigurationsInput{
+		Bucket: &bucketName,
+	})
+	require.NoError(t, err)
+
+	var configs []IntelligentTieringConfig
+	for _, c := range result.IntelligentTieringConfigurationList {
+		itc := IntelligentTieringConfig{
+			Name:   *c.Id,
+			Status: string(c.Status),
+		}
+		for _, tier := range c.Tierings {
+			days := int32(0)
+			if tier.Days != nil {
+				days = *tier.Days
+			}
+			itc.Tiers = append(itc.Tiers, IntelligentTieringTier{
+				AccessTier: string(tier.AccessTier),
+				Days:       days,
+			})
+		}
+		configs = append(configs, itc)
+	}
+	return configs
+}
+
+func (s *ComponentSuite) TestIntelligentTiering() {
+	const component = "s3-bucket/intelligent-tiering"
+	const stack = "default-test"
+	const awsRegion = "us-east-2"
+
+	defer s.DestroyAtmosComponent(s.T(), component, stack, nil)
+	options, _ := s.DeployAtmosComponent(s.T(), component, stack, nil)
+	assert.NotNil(s.T(), options)
+
+	bucketID := atmos.Output(s.T(), options, "bucket_id")
+	assert.NotEmpty(s.T(), bucketID)
+
+	configs := getS3BucketIntelligentTieringConfigs(s.T(), awsRegion, bucketID)
+	require.Len(s.T(), configs, 1)
+
+	assert.Equal(s.T(), "archive-config", configs[0].Name)
+	assert.Equal(s.T(), "Enabled", configs[0].Status)
+	require.Len(s.T(), configs[0].Tiers, 2)
+
+	tierMap := make(map[string]int32)
+	for _, tier := range configs[0].Tiers {
+		tierMap[tier.AccessTier] = tier.Days
+	}
+	assert.Equal(s.T(), int32(180), tierMap["ARCHIVE_ACCESS"])
+	assert.Equal(s.T(), int32(365), tierMap["DEEP_ARCHIVE_ACCESS"])
+
+	s.DriftTest(component, stack, nil)
 }
 
 func (s *ComponentSuite) TestEventNotifications() {

--- a/test/fixtures/stacks/catalog/usecase/intelligent-tiering.yaml
+++ b/test/fixtures/stacks/catalog/usecase/intelligent-tiering.yaml
@@ -1,0 +1,27 @@
+components:
+  terraform:
+    s3-bucket/intelligent-tiering:
+      metadata:
+        component: target
+      vars:
+        enabled: true
+        account_map_tenant_name: core
+        user_enabled: false
+        acl: "private"
+        grants: null
+        force_destroy: true
+        versioning_enabled: false
+        allow_encrypted_uploads_only: true
+        block_public_acls: true
+        block_public_policy: true
+        ignore_public_acls: true
+        restrict_public_buckets: true
+        allow_ssl_requests_only: true
+        lifecycle_configuration_rules: []
+        intelligent_tiering_configuration:
+          - name: archive-config
+            tiering:
+              - access_tier: ARCHIVE_ACCESS
+                days: 180
+              - access_tier: DEEP_ARCHIVE_ACCESS
+                days: 365

--- a/test/fixtures/stacks/orgs/default/test/tests.yaml
+++ b/test/fixtures/stacks/orgs/default/test/tests.yaml
@@ -3,3 +3,4 @@ import:
   - catalog/usecase/basic
   - catalog/usecase/disabled
   - catalog/usecase/event-notifications
+  - catalog/usecase/intelligent-tiering


### PR DESCRIPTION
## What

Add `intelligent_tiering_configuration` variable and pass it through to the upstream `cloudposse/s3-bucket/aws` module. This enables configuring archive access tiers within the INTELLIGENT_TIERING storage class.

Module source temporarily pointed to branch ref pending module release.

## Why

The module now supports `aws_s3_bucket_intelligent_tiering_configuration`, but the component doesn't expose it. Customers need to configure archive access tiers (e.g., Archive Access at 180d, Deep Archive Access at 365d) for cost optimization.

## Ref

- Module PR: https://github.com/cloudposse/terraform-aws-s3-bucket/pull/286

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added S3 Intelligent-Tiering configuration support, enabling automatic tiering of objects to archive access and deep archive access storage classes based on configurable day thresholds.
  * Expanded event notification options to support EventBridge, Lambda functions, SQS queues, and SNS topics with optional event filtering by prefix and suffix.

* **Chores**
  * Upgraded S3 module dependency to version 4.11.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->