### PR TITLE
chore: upgrade remote-state to v2.0.0

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -1,6 +1,6 @@
 module "account_map" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component   = var.account_map_component_name
   environment = var.account_map_enabled ? var.account_map_environment_name : ""

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -10,5 +10,9 @@ terraform {
       source  = "cloudposse/template"
       version = ">= 2.2.0"
     }
+    utils = {
+      source  = "cloudposse/utils"
+      version = ">= 2.0.0, < 3.0.0"
+    }
   }
 }

--- a/test/fixtures/vendor.yaml
+++ b/test/fixtures/vendor.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   sources:
     - component: "account-map"
-      source: github.com/cloudposse/terraform-aws-components.git//modules/account-map?ref={{.Version}}
-      version: 1.520.0
+      source: github.com/cloudposse-terraform-components/aws-account-map.git//src?ref={{.Version}}
+      version: v1.537.2
       targets:
         - "components/terraform/account-map"
       included_paths:


### PR DESCRIPTION
## Summary
- Upgrade `cloudposse/stack-config/yaml//modules/remote-state` from v1.x to v2.0.0
- This enables compatibility with `cloudposse/utils` provider v2.x
- Updates vendored account-map to standalone repo at v1.537.2

## Changes
- `src/remote-state.tf`: version pin `1.8.0`/`1.5.0` → `2.0.0`
- `src/versions.tf`: widen utils provider constraint (if applicable)
- `test/fixtures/vendor.yaml`: switch account-map to standalone repo (if applicable)

## Test plan
- [ ] CI lint passes (terraform init, no provider conflicts)
- [ ] Terratest passes in merge queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)